### PR TITLE
fix: reduce loop

### DIFF
--- a/balance.go
+++ b/balance.go
@@ -58,14 +58,12 @@ func (b *Balance) Get() string {
 
 	// Loop through the list of items and add the item's weight to the current weight.
 	// Also increment the total weight counter.
+	var max *Item
 	for _, item := range b.items {
 		item.current += item.weight
 		total += item.weight
-	}
 
-	// Select the item with max weight.
-	var max *Item
-	for _, item := range b.items {
+		// Select the item with max weight.
 		if max == nil || item.current > max.current {
 			max = item
 		}


### PR DESCRIPTION
Reduces the loops to a single loop, to reduce time taken for larger items

```
╰─❯ benchstat -delta-test ttest before.out after.out 
name                    old time/op    new time/op    delta
Balance/items-10-8        72.4ns ± 2%    71.1ns ± 2%     ~     (p=0.324 n=3+3)
Balance/items-100-8        176ns ± 2%     133ns ± 2%  -24.33%  (p=0.000 n=3+3)
Balance/items-1000-8      1.09µs ± 0%    0.77µs ± 1%  -29.42%  (p=0.000 n=3+3)
Balance/items-10000-8     13.8µs ± 1%     9.7µs ± 0%  -30.06%  (p=0.000 n=3+3)
Balance/items-100000-8     168µs ± 0%     106µs ± 2%  -36.89%  (p=0.000 n=3+3)
```